### PR TITLE
Fix snippet support looking for incorrect type in phpactor payload

### DIFF
--- a/pythonx/ncm2_phpactor.py
+++ b/pythonx/ncm2_phpactor.py
@@ -62,7 +62,7 @@ class Source(Ncm2Source):
             # snippet support
             m = re.search(r'(\w+\s+)?\w+\((.*)\)', menu)
 
-            if m and t == 'f':
+            if m and (t == 'function' or t == 'method'):
 
                 params = m.group(2)
 


### PR DESCRIPTION
Fixes #9 

The plugin was looking for a `type` of `f` in the `phpactor` JSON response, however `phpactor` appears to return types of `method` and `function`. Presumably the API changed at some point.