### PR TITLE
Tolerate the case where phpactor returns an error

### DIFF
--- a/pythonx/ncm2_phpactor.py
+++ b/pythonx/ncm2_phpactor.py
@@ -40,6 +40,9 @@ class Source(Ncm2Source):
 
         result = json.loads(result)
 
+        if not result or not result.get('suggestions', None):
+            return
+
         # {
         #     "suggestions": [
         #         {


### PR DESCRIPTION
Phpactor throws exceptions in some cases (for example when classes cannot be located). In these cases it returns a JSON response with `{"error": "blah"}` and does _not_ have the `['suggestions']` key.

This PR returns early if the `suggestions` key is not present.

The response from Phpactor is logged in NCM2. Phpactor does not log errors encountered during normal command execution (RPC errors are logged however). PR in Phpactor to fix this [here](https://github.com/phpactor/phpactor/pull/676)