### PR TITLE
Add timeout option

### DIFF
--- a/autoload/ncm2_phpactor.vim
+++ b/autoload/ncm2_phpactor.vim
@@ -3,6 +3,8 @@ if get(s:, 'loaded', 0)
 endif
 let s:loaded = 1
 
+let g:ncm2_phpactor_timeout = get(g:, 'ncm2_phpactor_timeout', 5)
+
 let g:ncm2_phpactor#proc = yarp#py3({
     \ 'module': 'ncm2_phpactor',
     \ 'on_load': { -> ncm2#set_ready(g:ncm2_phpactor#source)}

--- a/pythonx/ncm2_phpactor.py
+++ b/pythonx/ncm2_phpactor.py
@@ -13,6 +13,10 @@ logger = getLogger(__name__)
 
 class Source(Ncm2Source):
 
+    def __init__(self, nvim):
+        super(Source, self).__init__(nvim)
+        self.completion_timeout = self.nvim.eval('g:ncm2_phpactor_timeout') or 5
+
     def on_complete(self, ctx, lines, cwd, phpactor_complete):
         src = "\n".join(lines)
         src = self.get_src(src, ctx)
@@ -32,7 +36,7 @@ class Source(Ncm2Source):
                      stdout=subprocess.PIPE,
                      stderr=subprocess.DEVNULL)
 
-        result, errs = proc.communicate(src, timeout=5)
+        result, errs = proc.communicate(src, timeout=self.completion_timeout)
 
         result = result.decode()
 


### PR DESCRIPTION
Sometimes, phpactor will fail to run under 5 seconds. This adds a plugin
option — `g:ncm2_phpactor_timeout` — that defaults to 5 seconds but
allows the user to change if needed.

I didn't find a contribution guide, so let me know if anything needs changing :)