### PR TITLE
Add info field to display preview

### DIFF
--- a/pythonx/ncm2_phpactor.py
+++ b/pythonx/ncm2_phpactor.py
@@ -64,7 +64,7 @@ class Source(Ncm2Source):
             word = e['name']
             t = e['type']
 
-            item = dict(word=word, menu=menu)
+            item = dict(word=word, menu=menu, info=menu)
 
             # snippet support
             m = re.search(r'(\w+\s+)?\w+\((.*)\)', menu)


### PR DESCRIPTION
Fill `'info'` key to trigger vim preview window as a temporary solution to #19