### PR TITLE
Add auto import upon class completion

### DIFF
--- a/autoload/ncm2_phpactor.vim
+++ b/autoload/ncm2_phpactor.vim
@@ -45,3 +45,28 @@ func! ncm2_phpactor#on_complete(ctx)
                 \       ])
 endfunc
 
+function! ncm2_phpactor#_completeImportClassFromNcm2(completedItem)
+
+    if !has_key(a:completedItem, "word") || !has_key(a:completedItem, "user_data")
+        return
+    endif
+
+    let user_data = json_decode(a:completedItem['user_data'])
+
+    if (user_data['source'] !=# "phpactor")
+        return
+    endif
+
+    if !empty(get(a:completedItem, "info", ""))
+        call phpactor#rpc("import_class", {
+                    \ "qualified_name": a:completedItem['info'],
+                    \ "offset": phpactor#_offset(),
+                    \ "source": phpactor#_source(),
+                    \ "path": expand('%:p')})
+    endif
+
+endfunction
+
+if g:phpactorOmniAutoClassImport == v:true
+    autocmd CompleteDone *.php call ncm2_phpactor#_completeImportClassFromNcm2(v:completed_item)
+endif


### PR DESCRIPTION
The current behavior of this is that the pop up menu will open back up after the import statement is added. This seems annoying at first, but it's nice in that it allows you to start typing `::` if you'd like to access a static method. I'm not sure if there's a way to keep it closed afterwards as it opens on insert mode automatically. If this is undesired I might need some help in exploring those options, and we could tuck that behavior behind another boolean vimrc variable.

Looks like this affects #8 and possibly #17 as well.

Here's a GIF of this in action:

![2019-07-28_06:43:19_fatboyxpc](https://user-images.githubusercontent.com/744962/62005566-13fee180-b103-11e9-96ee-0bc26fa83630.gif)
