### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'group'

### DIFF
--- a/pythonx/ncm2_phpactor.py
+++ b/pythonx/ncm2_phpactor.py
@@ -87,6 +87,8 @@ class Source(Ncm2Source):
                             # skip params with default value
                             break
                         else:
+                            if not re.search(r'\$\w+', param):
+                                break
                             param = re.search(r'\$\w+', param).group()
                             ph = self.snippet_placeholder(num, param)
                             placeholders.append(ph)


### PR DESCRIPTION
This fixes the issue with failing regex parameter parsing in some situations. 

The error is:
`[ncm2_phpactor@yarp] AttributeError: 'NoneType' object has no attribute 'group'`

More info from another user here https://github.com/phpactor/ncm2-phpactor/issues/22#issuecomment-974883949

I've just added this small check to avoid crashing. Probably it's not the most elegant solution, but I'm currently testing the fix and it seems everything is working fine and not crashing.